### PR TITLE
Default BPE cache directory to Path.GetTempPath() to avoid infrastructure side effects

### DIFF
--- a/TiktokenSharp/Services/EncodingManager.cs
+++ b/TiktokenSharp/Services/EncodingManager.cs
@@ -22,7 +22,7 @@ namespace TiktokenSharp.Services
             get { return _instance.Value; }
         }
 
-        public string PBEFileDirectory { get; set; } = Path.Combine(AppContext.BaseDirectory, "bpe");
+        public string PBEFileDirectory { get; set; } = Path.Combine(Path.GetTempPath(), "bpe");
 
 
         const string ENDOFTEXT = "<|endoftext|>";
@@ -312,7 +312,7 @@ namespace TiktokenSharp.Services
             if (tikTokenBpeFile.StartsWith("http"))
             {
                 var fileName = Path.GetFileName(tikTokenBpeFile);
-                var saveDir = PBEFileDirectory; //Path.Combine(AppContext.BaseDirectory, "bpe");
+                var saveDir = PBEFileDirectory; //Path.Combine(Path.GetTempPath(), "bpe");
 
                 try
                 {

--- a/TiktokenSharp/TikToken.cs
+++ b/TiktokenSharp/TikToken.cs
@@ -27,7 +27,7 @@ namespace TiktokenSharp
         /// <summary>
         /// You can set this item before EncodingForModel to specify the location for storing and downloading the bpe file. If not set, it defaults to the AppContext.BaseDirectory\bpe directory.
         /// </summary>
-        public static string PBEFileDirectory { get; set; } = Path.Combine(AppContext.BaseDirectory, "bpe");
+        public static string PBEFileDirectory { get; set; } = Path.Combine(Path.GetTempPath(), "bpe");
 
         /// <summary>
         /// get encoding with modelName


### PR DESCRIPTION
The library defaults to creating the bpe cache folder in AppContext.BaseDirectory. In Azure Functions, writing to the app folder at runtime triggers an automatic host restart. This kills any currently running tasks, which in my case caused 30-minute hangs while the system waited for the "interrupted" work to timeout.

2026-02-20T16:01:01.063007532Z info: Host.Startup[0]
2026-02-20T16:01:01.063046432Z       Directory change of type 'Created' detected for '/home/site/wwwroot/bpe'
2026-02-20T16:01:01.063063633Z info: Host.Startup[0]
2026-02-20T16:01:01.063067933Z       Host configuration has changed. Signaling restart

Solution
 I’ve changed the default cache path to Path.GetTempPath(). This is a standard practice for library caches and ensures that initializing the tokenizer doesn't trigger unexpected infrastructure restarts in cloud environments.